### PR TITLE
Prevent duplicate entry in `first` and `last`

### DIFF
--- a/birdie_snapshots/first_from_first.accepted
+++ b/birdie_snapshots/first_from_first.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.1.8
+title: first_from_first
+file: ./test/zip_list_test.gleam
+test_name: first_from_first_test
+---
+ZipList([], 1, [2, 3, 4, 5])

--- a/birdie_snapshots/last_from_last.accepted
+++ b/birdie_snapshots/last_from_last.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.1.8
+title: last_from_last
+file: ./test/zip_list_test.gleam
+test_name: last_from_last_test
+---
+ZipList([1, 2, 3, 4], 5, [])

--- a/src/zip_list.gleam
+++ b/src/zip_list.gleam
@@ -125,16 +125,15 @@ pub fn backwards(zip_list: ZipList(a), times: Int) -> ZipList(a) {
 /// first(numbers) == new([], 1, [2, 3, 4, 5])
 /// ```
 pub fn first(zip_list: ZipList(a)) -> ZipList(a) {
-  let #(new_current, previous_tail) = case zip_list.previous {
-    [] -> #(zip_list.current, [])
-    [head, ..tail] -> #(head, tail)
+  case zip_list.previous {
+    [] -> zip_list
+    [head, ..tail] ->
+      ZipList(
+        previous: [],
+        current: head,
+        next: list.append(tail, [zip_list.current, ..zip_list.next]),
+      )
   }
-
-  ZipList(
-    previous: [],
-    current: new_current,
-    next: list.append(previous_tail, [zip_list.current, ..zip_list.next]),
-  )
 }
 
 /// Move the cursor N elements forward
@@ -195,16 +194,18 @@ pub fn jump(zip_list: ZipList(a), index: Int) -> ZipList(a) {
 /// last(numbers) == new([1, 2, 3, 4], 5, [])
 /// ```
 pub fn last(zip_list: ZipList(a)) -> ZipList(a) {
-  let #(new_current, next_tail) = case list.reverse(zip_list.next) {
-    [] -> #(zip_list.current, [])
-    [head, ..tail] -> #(head, list.reverse(tail))
+  case list.reverse(zip_list.next) {
+    [] -> zip_list
+    [head, ..tail] ->
+      ZipList(
+        previous: list.append(zip_list.previous, [
+          zip_list.current,
+          ..list.reverse(tail)
+        ]),
+        current: head,
+        next: [],
+      )
   }
-
-  ZipList(
-    previous: list.append(zip_list.previous, [zip_list.current, ..next_tail]),
-    current: new_current,
-    next: [],
-  )
 }
 
 /// Move the cursor to the next element

--- a/test/zip_list_test.gleam
+++ b/test/zip_list_test.gleam
@@ -65,6 +65,13 @@ pub fn first_test() {
   |> birdie.snap("first")
 }
 
+pub fn first_from_first_test() {
+  zip_list.new([], 1, [2, 3, 4, 5])
+  |> zip_list.first
+  |> string.inspect
+  |> birdie.snap("first_from_first")
+}
+
 pub fn forward_test() {
   zip_list.new([1, 2, 3], 4, [5, 6, 7])
   |> zip_list.forward(2)
@@ -91,6 +98,13 @@ pub fn last_test() {
   |> zip_list.last
   |> string.inspect
   |> birdie.snap("last")
+}
+
+pub fn last_from_last_test() {
+  zip_list.new([1, 2, 3, 4], 5, [])
+  |> zip_list.last
+  |> string.inspect
+  |> birdie.snap("last_from_last")
 }
 
 pub fn next_test() {


### PR DESCRIPTION
The `first` and `last` functions are duplicating the `current` entry when the zip_list is focused on the first or last element in the list.  This change just returns the list as is when either of those condition is met.

Before this change, the outputs of the snapshot tests were:
```gleam
ZipList([], 1, [1, 2, 3, 4, 5])
```
and
```gleam
ZipList([1, 2, 3, 4, 5], 5, [])
```