### PR TITLE
Allow type to change in `current_map`

### DIFF
--- a/birdie_snapshots/current_map_different_type.accepted
+++ b/birdie_snapshots/current_map_different_type.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.1.8
+title: current_map_different_type
+file: ./test/zip_list_test.gleam
+test_name: current_map_different_type_test
+---
+ZipList(["1", "2", "3"], "is_current", ["5", "6", "7"])

--- a/src/zip_list.gleam
+++ b/src/zip_list.gleam
@@ -376,7 +376,7 @@ pub fn append_previous(zip_list: ZipList(a), previous: List(a)) -> ZipList(a) {
 ///   }
 /// }) == new([2, 4], 30, [8, 10])
 /// ```
-pub fn current_map(zip_list: ZipList(a), f: fn(a, Bool) -> a) -> ZipList(a) {
+pub fn current_map(zip_list: ZipList(a), f: fn(a, Bool) -> b) -> ZipList(b) {
   let f_with_flag = fn(element) { f(element, False) }
 
   ZipList(

--- a/test/zip_list_test.gleam
+++ b/test/zip_list_test.gleam
@@ -175,6 +175,18 @@ pub fn current_map_test() {
   |> birdie.snap("current_map")
 }
 
+pub fn current_map_different_type_test() {
+  zip_list.new([1, 2, 3], 4, [5, 6, 7])
+  |> zip_list.current_map(fn(x, is_current) {
+    case is_current {
+      True -> "is_current"
+      False -> int.to_string(x)
+    }
+  })
+  |> string.inspect
+  |> birdie.snap("current_map_different_type")
+}
+
 pub fn filter_test() {
   zip_list.new([1, 2, 3], 4, [5, 6, 7])
   |> zip_list.filter(int.is_odd)


### PR DESCRIPTION
`current_map` does not let you map the values in the list to a new type.  For example if you have a list of integers you can't convert them to strings.  This change is to allow mapping from generic type `a` to any generic type `b`.